### PR TITLE
Update near101_chapter_1.md to use testnet.mynearwallet.com

### DIFF
--- a/content/near101_chapter_1.md
+++ b/content/near101_chapter_1.md
@@ -219,7 +219,7 @@ For this learning module we will use `myaccount.testnet` as the first account an
 
 ### 4.1 Create a Top-Level Account
 
-Go to the [NEAR Testnet wallet](https://wallet.testnet.near.org/) page and create a new account by following these steps:
+Go to the [MyNearWallet Testnet](https://testnet.mynearwallet.com/) page and create a new account by following these steps:
 
 1. Open the wallet.
 2. Choose a name for your account.


### PR DESCRIPTION
The official Near wallet website has discontinued its wallets, including the testnet previously accessible at https://wallet.testnet.near.org/. As recommended by Near, an alternative wallet that offers a user experience similar to the Near wallet website is available at mynearwallet.com.

This update changes the discontinued Near testnet URL to the new address: https://testnet.mynearwallet.com/.